### PR TITLE
Strip DTD, head and body tags from returned HTML

### DIFF
--- a/menu-section-titles.php
+++ b/menu-section-titles.php
@@ -59,5 +59,5 @@ function zw_menu_section_titles ( $items, $args ) {
 	}
 
 	// return the string
-	return $dom->saveHTML();
+	return preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $dom->saveHTML());
 }


### PR DESCRIPTION
`DOMDocument` in some PHP versions adds DTD, head and body tags if they're missing when using `loadHTML`. See http://php.net/manual/en/domdocument.savehtml.php#85165 and http://stackoverflow.com/questions/11216726/php-domdocument-without-the-dtd-head-and-body-tags